### PR TITLE
Add migrations

### DIFF
--- a/gb-backend/.gitignore
+++ b/gb-backend/.gitignore
@@ -12,3 +12,6 @@
 
 # local configuration
 /config/local.js
+
+# migration state store
+/.migrate

--- a/gb-backend/migrations/1558332653416-first.js
+++ b/gb-backend/migrations/1558332653416-first.js
@@ -1,0 +1,42 @@
+'use strict'
+const config = require('../config')
+const { createContainer } = require('../src/di')
+
+const container = createContainer(config)
+
+module.exports.up = function (next) {
+  container.mariapool.query(`
+    CREATE TABLE builds (
+     id int(11) NOT NULL AUTO_INCREMENT,
+     charname varchar(255) DEFAULT NULL,
+     class varchar(255) DEFAULT NULL,
+     mastery1 varchar(255) DEFAULT NULL,
+     mastery2 varchar(255) DEFAULT NULL,
+     damagetype varchar(255) DEFAULT NULL,
+     activeskills varchar(255) DEFAULT NULL,
+     passiveskills varchar(255) DEFAULT NULL,
+     playstyle varchar(255) DEFAULT NULL,
+     version varchar(255) DEFAULT NULL,
+     gearreq varchar(255) DEFAULT NULL,
+     cruci varchar(255) DEFAULT NULL,
+     srlevel varchar(255) DEFAULT NULL,
+     guide varchar(4096) DEFAULT NULL,
+     author varchar(255) DEFAULT NULL,
+     primaryskill varchar(255) DEFAULT NULL,
+     link varchar(255) DEFAULT NULL,
+     purpose varchar(255) DEFAULT NULL,
+     blurb varchar(1024) DEFAULT NULL,
+     PRIMARY KEY (id)
+    ) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=latin1;
+  `)
+  .then(() => next())
+  .catch(next)
+}
+
+module.exports.down = function (next) {
+  container.mariapool.query(`
+    drop table if exists builds
+  `)
+  .then(() => next())
+  .catch(next)
+}

--- a/gb-backend/package-lock.json
+++ b/gb-backend/package-lock.json
@@ -13,10 +13,25 @@
         "negotiator": "0.6.2"
       }
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -50,10 +65,41 @@
         }
       }
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -107,6 +153,11 @@
         "lodash.get": "~4.4.2"
       }
     },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -143,6 +194,11 @@
       "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-2.0.1.tgz",
       "integrity": "sha512-/CCG157H//3l513omROUzaREChY/OYpxqYXvQcv7gsrwGfjVOh5d/1gJigHJ6iTnO77pA8rMLZ63CgEPEM6+9Q=="
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -157,6 +213,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "etag": {
       "version": "1.8.1",
@@ -268,6 +329,14 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "optional": true
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -356,6 +425,21 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
+    "migrate": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/migrate/-/migrate-1.6.2.tgz",
+      "integrity": "sha512-XAFab+ArPTo9BHzmihKjsZ5THKRryenA+lwob0R+ax0hLDs7YzJFJT5YZE3gtntZgzdgcuFLs82EJFB/Dssr+g==",
+      "requires": {
+        "chalk": "^1.1.3",
+        "commander": "^2.9.0",
+        "dateformat": "^2.0.0",
+        "dotenv": "^4.0.0",
+        "inherits": "^2.0.3",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^0.5.1",
+        "slug": "^0.9.2"
+      }
+    },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -372,6 +456,27 @@
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
         "mime-db": "1.40.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
       }
     },
     "ms": {
@@ -538,6 +643,14 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "slug": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.4.tgz",
+      "integrity": "sha512-3YHq0TeJ4+AIFbJm+4UWSQs5A1mmeWOTQqydW3OoPmQfNKxlO96NDRTIrp+TBkmvEsEFrd+Z/LXw8OD/6OlZ5g==",
+      "requires": {
+        "unicode": ">= 0.3.1"
+      }
+    },
     "sqlstring": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
@@ -552,6 +665,19 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.8.tgz",
       "integrity": "sha512-1q+dL790Ps0NV33rISMq9OLtfDA9KMJZdo1PHZXE85orrWsM4FAh8CVyAOTHO0rhyeM138KNPngBPrx33bFsxw=="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -571,6 +697,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "unicode": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/unicode/-/unicode-11.0.1.tgz",
+      "integrity": "sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/gb-backend/package.json
+++ b/gb-backend/package.json
@@ -9,10 +9,12 @@
     "express": "^4.16.4",
     "json-2-csv": "^3.5.3",
     "jsonfile": "^5.0.0",
+    "migrate": "^1.6.2",
     "mysql2": "^1.6.5",
     "ramda": "^0.26.1"
   },
   "scripts": {
-    "start": "node ./index"
+    "start": "node ./index",
+    "migrate": "./node_modules/.bin/migrate"
   }
 }


### PR DESCRIPTION
to migrate to the latest database(s):
```
npm run migrate
```
to create a new migration:
```
npm run migrate create foo
```

to keep your existing pre-`migrate` database, first write a file in `gb-backend/.migrate` with something like this in it:

```
{
  "lastRun": "1558332653416-first.js",
  "migrations": [
    {
      "title": "1558332653416-first.js",
      "timestamp": 1558333058091
    }
  ]
}
```

Alternatively you could probably also just rename your table, then copy the data into the new table created by `migrate` with something like this:

In SQL:

```
rename table builds to builds_renamed;
```

In bash in `gb-backend`:

```
npm run migrate
```

Back in SQL again:
```
insert into builds select * from builds_renamed;
/* check results */
select * from builds;
/* if results are good, delete the old table */
drop table builds_renamed;
```